### PR TITLE
fixed the symlink command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ It's the same as any other Homesick castle (keep in mind that you can have more 
 
     gem install homesick
     homesick clone benjaminoakes/homesick-vi-everywhere
-    homesick symlink benjaminoakes/homesick-vi-everywhere
+	homesick symlink homesick-vi-everywhere
 
 If you want to modify your shell so that `vi` is used in more cases, source `vi-everywhere` like so:
 


### PR DESCRIPTION
I tried to install homesick on a clean mac (never had homesick or vi keybindings on it) . It looks like the symlink command in the readme doesn't work. I'm not sure when the homesick symlink syntax changed, but the change in this commit (removing the repo name) made it work for me.

I'm using homesick version 1.1.1 .
